### PR TITLE
Update converter.py

### DIFF
--- a/tools/converter.py
+++ b/tools/converter.py
@@ -38,7 +38,7 @@ from common import StringFormatter
 ################################
 # common definitions
 ################################
-BUILD_OUTPUT_DIR = 'build'
+BUILD_OUTPUT_DIR = 'builds'
 PHONE_DATA_DIR = "/data/local/tmp/mace_run"
 MODEL_OUTPUT_DIR_NAME = 'model'
 MODEL_HEADER_DIR_PATH = 'include/mace/public'


### PR DESCRIPTION
解决 MacOS 中遇到的，因为 mace 目录下 bazel 的 BUILD 文件与 build 重名，而 makedirs build/mobilenet 不成功的问题。