### PR TITLE
tools: support more adb device scenarios

### DIFF
--- a/tools/sh_commands.py
+++ b/tools/sh_commands.py
@@ -115,7 +115,7 @@ def clear_phone_data_dir(serialno, phone_data_dir):
 ################################
 def adb_devices():
     serialnos = []
-    p = re.compile(r'(\w+)\s+device')
+    p = re.compile(r'([\w|-]+)\s+device')
     for line in split_stdout(sh.adb("devices")):
         m = p.match(line)
         if m:


### PR DESCRIPTION
Some devices generate `adb devices` message with `-` which
is ignored by current tools. This patch enables them.