### PR TITLE
fix converted model folder description error in docs

### DIFF
--- a/docs/user_guide/basic_usage.rst
+++ b/docs/user_guide/basic_usage.rst
@@ -197,7 +197,7 @@ When the deployment file is ready, you can use MACE converter tool to convert yo
     python tools/converter.py convert --config=/path/to/your/model_deployment_file.yml
 
 This command will download or load your pre-trained model and convert it to a MACE model proto file and weights data file.
-The generated model files will be stored in ``build/${library_name}/model`` folder.
+The generated model files will be stored in ``builds/${library_name}/model`` folder.
 
 .. warning::
 


### PR DESCRIPTION
According to [tools/converter.py](https://github.com/XiaoMi/mace/blob/master/tools/converter.py/#L47), it should be `builds/` not `build/`.
Efforts to find the converted model file.