### PR TITLE
Made str2vec_maps.cc.jinja2 template python 2.7 & Python 3+ compatible

### DIFF
--- a/mace/python/tools/str2vec_maps.cc.jinja2
+++ b/mace/python/tools/str2vec_maps.cc.jinja2
@@ -22,7 +22,7 @@ namespace mace {
 
 extern const std::map<std::string, std::vector<{{data_type}}>> {{variable_name}} =
 {
-  {% for key, value in maps.iteritems() %}
+  {% for key, value in maps.items() %}
   {
     "{{key}}",
     {


### PR DESCRIPTION
When running the bazel build commands using python3 I would get this error:
```
ERROR: /home/user/XiaoMi/mace-master/mace/codegen/BUILD:22:1: no such target '@local_opencl_kernel_encrypt//:gen/encrypt_opencl_kernel': target 'gen/encrypt_opencl_kernel' not declared in package ''
```

After changing the code above the issue was resolved.
I checked the template again in python2.7 and it still runs, so I think .items() works here.