### PR TITLE
bugfix: 修复使用benchmark命令时，无法正确地测试GPU的性能

### DIFF
--- a/tools/device.py
+++ b/tools/device.py
@@ -842,7 +842,7 @@ class DeviceWrapper:
             if target_abi == ABIType.host:
                 runtime_list.append(RuntimeType.cpu)
             elif model_runtime == RuntimeType.cpu_gpu:
-                runtime_list.extend([RuntimeType.cpu, RuntimeType.cpu_gpu])
+                runtime_list.extend([RuntimeType.cpu, RuntimeType.gpu])
             else:
                 runtime_list.append(model_runtime)
             for runtime in runtime_list:


### PR DESCRIPTION
修复使用benchmark命令时，传入的device是cpu+gpu，而mace的某些方法只能检测cpu或者gpu这种形式(而不是cpu+gpu)，因此需要将cpu和gpu分开加入到runtime_list中，否则无法执行GPU。