### PR TITLE
Fix problem: workspace::LoadModelTensor create tensor without name. A…

### DIFF
--- a/mace/core/workspace.cc
+++ b/mace/core/workspace.cc
@@ -131,7 +131,7 @@ MaceStatus Workspace::LoadModelTensor(const NetDef &net_def,
         }
 
         std::unique_ptr<Tensor> tensor(
-            new Tensor(device->allocator(), dst_data_type, true));
+            new Tensor(device->allocator(), dst_data_type, true, const_tensor.name()));
         tensor->Resize(dims);
 
         MACE_CHECK(tensor->size() == const_tensor.data_size(),


### PR DESCRIPTION
…lthough It is no a bug, It is better to fix that to unify the tensor structure and debug it effectively