### PR TITLE
Fixed NaN propagation from channel paddings on GPU

### DIFF
--- a/mace/ops/opencl/cl/eltwise.cl
+++ b/mace/ops/opencl/cl/eltwise.cl
@@ -83,21 +83,22 @@ __kernel void eltwise(OUT_OF_RANGE_PARAMS
   #endif
 #endif
 
-#if INPUT_TYPE == 1 || INPUT_TYPE == 4
-  #if ELTWISE_TYPE == 0 || ELTWISE_TYPE == 1 || ELTWISE_TYPE == 4 ||          \
-      ELTWISE_TYPE == 5 || ELTWISE_TYPE == 8 || ELTWISE_TYPE == 9
-    const int remain_channel = channel - 4 * chan_idx;
-    if (remain_channel < 4) {
-      switch (remain_channel) {
-        case 1:
-          out.y = 0;
-        case 2:
-          out.z = 0;
-        case 3:
-          out.w = 0;
-      }
+#if ((INPUT_TYPE == 1 || INPUT_TYPE == 4) &&                            \
+     (ELTWISE_TYPE == 0 || ELTWISE_TYPE == 1 || ELTWISE_TYPE == 4 ||    \
+      ELTWISE_TYPE == 5 || ELTWISE_TYPE == 8 || ELTWISE_TYPE == 9)) ||  \
+    ((INPUT_TYPE != 1 || INPUT_TYPE != 4) &&                            \
+     (ELTWISE_TYPE == 3 || ELTWISE_TYPE == 9))
+  const int remain_channel = channel - 4 * chan_idx;
+  if (remain_channel < 4) {
+    switch (remain_channel) {
+      case 1:
+        out.y = 0;
+      case 2:
+        out.z = 0;
+      case 3:
+        out.w = 0;
     }
-  #endif
+  }
 #endif
 
   WRITE_IMAGET(output, (int2)(pos, hb), out);


### PR DESCRIPTION
Non-pointwise (i.e. kernel size != 1x1) convolutions with "SAME" padding return incorrect results when applied after element-wise division. This occurs only when both tensor operands of division have the same number of channels `C`, where `C` is not a multiply of 4, because of zero-padding applied to such tensors.

The source of the problem is performing division on channel pads which are filled by zeros - since both sides of division are zeros this operation returns `NaN` (see: The OpenCL Specification: 6.3 Operators & IEEE Standard for Floating-Point Arithmetic: 7.2 Invalid operation).

The problem is not limited to division. In case of `pow` function it is even more dangerous: instruction `pow(0., 0.)` returns `1` (see: The OpenCL Specification: 7.5 Edge Case Behavior), so there's no such a clear indicator of a problem.
