### PR TITLE
fix blank name for onnx model, use output name instead

### DIFF
--- a/mace/python/tools/converter_tool/onnx_converter.py
+++ b/mace/python/tools/converter_tool/onnx_converter.py
@@ -230,6 +230,8 @@ def onnx_dtype(dtype):
 class OnnxNode(object):
     def __init__(self, node):
         self.name = str(node.name)
+        if self.name=='':
+            self.name = str(node.output)
         self.op_type = str(node.op_type)
         self.domain = str(node.domain)
         self.attrs = dict([(attr.name,

--- a/mace/python/tools/converter_tool/onnx_converter.py
+++ b/mace/python/tools/converter_tool/onnx_converter.py
@@ -230,7 +230,7 @@ def onnx_dtype(dtype):
 class OnnxNode(object):
     def __init__(self, node):
         self.name = str(node.name)
-        if self.name=='':
+        if self.name == '':
             self.name = str(node.output)
         self.op_type = str(node.op_type)
         self.domain = str(node.domain)


### PR DESCRIPTION
Fix https://github.com/XiaoMi/mace/issues/383
Onnx node dosen't have name, then using output name instead.