### PR TITLE
Fix outdated link to base_converter.py.

### DIFF
--- a/docs/development/data_format.md
+++ b/docs/development/data_format.md
@@ -38,7 +38,7 @@ Based on these conditions, We partition the ops into 3 categories.
 By default, the operators not in either `FixedDataFormatOps` or `TransposableDataFormatOps`
 are listed in `SourceDataFormatOps`.
 
-For detailed information, you could refer to [code](https://github.com/XiaoMi/mace/blob/master/mace/python/tools/converter_tool/base_converter.py).
+For detailed information, you could refer to [code](https://github.com/XiaoMi/mace/blob/master/tools/python/transform/base_converter.py).
 
 
 Data Format in Operator


### PR DESCRIPTION
Link was broken after refactoring at https://github.com/XiaoMi/mace/commit/320b509c79bbf073f04ec5da07c201f6bffb98f9