### PR TITLE
Add support for ReLU6 op in CAFFE

### DIFF
--- a/third_party/caffe/Dockerfile
+++ b/third_party/caffe/Dockerfile
@@ -29,8 +29,9 @@ WORKDIR $CAFFE_ROOT
 
 # FIXME: use ARG instead of ENV once DockerHub supports this
 # https://github.com/docker/hub-feedback/issues/460
-# ENV CLONE_TAG=1.0
-ENV CLONE_TAG=master
+ENV CLONE_TAG=1.0
+# To enable Clip operation in CAFFE during validation, it's needed to set CLONE_TAG=master
+# ENV CLONE_TAG=master
 
 # ImportError in system pip wrappers after an upgrade.
 # https://github.com/pypa/pip/issues/5599

--- a/third_party/caffe/Dockerfile
+++ b/third_party/caffe/Dockerfile
@@ -29,7 +29,8 @@ WORKDIR $CAFFE_ROOT
 
 # FIXME: use ARG instead of ENV once DockerHub supports this
 # https://github.com/docker/hub-feedback/issues/460
-ENV CLONE_TAG=1.0
+# ENV CLONE_TAG=1.0
+ENV CLONE_TAG=master
 
 # ImportError in system pip wrappers after an upgrade.
 # https://github.com/pypa/pip/issues/5599

--- a/third_party/caffe/caffe.proto
+++ b/third_party/caffe/caffe.proto
@@ -437,7 +437,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 147 (last added: recurrent_param)
+// LayerParameter next available layer-specific ID: 149 (last added: clip_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -494,6 +494,7 @@ message LayerParameter {
   optional ArgMaxParameter argmax_param = 103;
   optional BatchNormParameter batch_norm_param = 139;
   optional BiasParameter bias_param = 141;
+  optional ClipParameter clip_param = 148;
   optional ConcatParameter concat_param = 104;
   optional ContrastiveLossParameter contrastive_loss_param = 105;
   optional ConvolutionParameter convolution_param = 106;
@@ -776,6 +777,12 @@ message ArgMaxParameter {
   // By default ArgMaxLayer maximizes over the flattened trailing dimensions
   // for each index of the first / num dimension.
   optional int32 axis = 3;
+}
+
+// Message that stores parameters used by ClipLayer
+message ClipParameter {
+  required float min = 1;
+  required float max = 2;
 }
 
 message ConcatParameter {

--- a/tools/python/transform/caffe_converter.py
+++ b/tools/python/transform/caffe_converter.py
@@ -164,6 +164,7 @@ class CaffeConverter(base_converter.ConverterInterface):
         'PReLU': ActivationType.PRELU,
         'TanH': ActivationType.TANH,
         'Sigmoid': ActivationType.SIGMOID,
+        'Clip': ActivationType.RELUX,
     }
 
     def __init__(self, option, src_model_file, src_weight_file):
@@ -177,6 +178,7 @@ class CaffeConverter(base_converter.ConverterInterface):
             'TanH': self.convert_activation,
             'Sigmoid': self.convert_activation,
             'PReLU': self.convert_activation,
+            'Clip': self.convert_activation,
             'Pooling': self.convert_pooling,
             'Concat': self.convert_concat,
             'Slice': self.convert_slice,
@@ -505,6 +507,13 @@ class CaffeConverter(base_converter.ConverterInterface):
             param_arg.f = caffe_op.layer.relu_param.negative_slope
 
             type_arg.s = six.b(ActivationType.LEAKYRELU.name)
+
+        if caffe_op.type == 'Clip':
+            mace_check(caffe_op.layer.clip_param.min == 0,
+                       "Mace only supports min == 0 Clip op")
+            limit_arg = op.arg.add()
+            limit_arg.name = MaceKeyword.mace_activation_max_limit_str
+            limit_arg.f = caffe_op.layer.clip_param.max
 
     def convert_folded_batchnorm(self, caffe_op):
         op = self.convert_general_op(caffe_op)


### PR DESCRIPTION
Currently `ReLU6` isn't supported in CAFFE, therefore it's not implemented in MACE for CAFFE as well. But `master` branch of CAFFE includes a `Clip` op that can be used to limit input tensor within a specific range. 

We can use CAFFE `Clip` layer to implement `ReLU6` op in CAFFE and consequently in MACE for CAFFE.

I've already tested these modifications with mobilenetv2-like models and conversion/run/validation are successful (to run validation, first delete old caffe container/image to let MACE build the new one).