### PR TITLE
Let `subprocess.Popen` open outputs in text mode

### DIFF
--- a/tools/device.py
+++ b/tools/device.py
@@ -243,7 +243,8 @@ class DeviceWrapper:
                     "--model_file=%s" % mace_model_path,
                 ],
                 stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE)
+                stdout=subprocess.PIPE,
+                universal_newlines=True)
             out, err = p.communicate()
             self.stdout = err + out
             six.print_(self.stdout)


### PR DESCRIPTION
Fix: Messages from `mace_run.cc` is printed as `Bytes`