### PR TITLE
Fix: CMake static library

### DIFF
--- a/mace/codegen/CMakeLists.txt
+++ b/mace/codegen/CMakeLists.txt
@@ -29,9 +29,6 @@ add_custom_target(opencl_kernel_src DEPENDS ${MACE_OPENCL_KERNELS_SRC}
 add_library(generated_opencl_kernel ${MACE_OPENCL_KERNELS_SRC})
 add_dependencies(generated_opencl_kernel opencl_kernel_src)
 
-install(TARGETS generated_version ARCHIVE DESTINATION lib)
-install(TARGETS generated_opencl_kernel ARCHIVE DESTINATION lib)
-
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/null.cc "")
 file(GLOB CODEGEN_MODELS ${CMAKE_CURRENT_BINARY_DIR}/null.cc models/**/code/*.cc)
 

--- a/mace/core/CMakeLists.txt
+++ b/mace/core/CMakeLists.txt
@@ -83,9 +83,8 @@ if(MACE_ENABLE_MTK_APU)
 endif(MACE_ENABLE_MTK_APU)
 
 add_library(core STATIC ${CORE_SRCS})
-target_link_libraries(core PRIVATE
+target_link_libraries(core PUBLIC
   proto
-  utils
   port
   generated_version
   ${EXTRA_LINK_LIBS}

--- a/mace/core/CMakeLists.txt
+++ b/mace/core/CMakeLists.txt
@@ -83,8 +83,9 @@ if(MACE_ENABLE_MTK_APU)
 endif(MACE_ENABLE_MTK_APU)
 
 add_library(core STATIC ${CORE_SRCS})
-target_link_libraries(core PUBLIC
+target_link_libraries(core PRIVATE
   proto
+  utils
   port
   generated_version
   ${EXTRA_LINK_LIBS}
@@ -99,5 +100,3 @@ endif(MACE_ENABLE_OPENCL)
 if(MACE_ENABLE_QUANTIZE)
   add_dependencies(core gemmlowp)
 endif(MACE_ENABLE_QUANTIZE)
-
-install(TARGETS core ARCHIVE DESTINATION lib)

--- a/mace/libmace/CMakeLists.txt
+++ b/mace/libmace/CMakeLists.txt
@@ -7,8 +7,40 @@ if(NOT APPLE)
     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mace_version_script.lds")
 endif(NOT APPLE)
 
-add_library(mace_static STATIC ${LIBMACE_SRCS})
-target_link_libraries(mace_static PUBLIC ops)
+add_library(mace_API STATIC ${LIBMACE_SRCS})
+target_link_libraries(mace_API ops)
+
+set(BASE_PATH ${CMAKE_BINARY_DIR})
+if(ANDROID)
+  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
+                "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n"
+                "addlib ${CMAKE_BINARY_DIR}/mace/port/android/libport_android.a")
+elseif(APPLE)
+  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
+                "addlib ${CMAKE_BINARY_DIR}/mace/port/darwin/libport_darwin.a")
+elseif(WIN32)
+  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/windows/libport_windows.a")
+else(WIN32)
+  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
+                "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n"
+                "addlib ${CMAKE_BINARY_DIR}/mace/port/linux/libport_linux.a")
+endif(ANDROID)
+configure_file("${CMAKE_SOURCE_DIR}/mace/libmace/mace.mri.in" 
+               "${CMAKE_BINARY_DIR}/mace/libmace/mace.mri")
+
+set(STATIC_LIB ${CMAKE_BINARY_DIR}/mace/libmace/libmace_static.a)
+add_custom_target(combined ALL
+        COMMAND ar -M < ${CMAKE_BINARY_DIR}/mace/libmace/mace.mri
+        DEPENDS mace_API ops core utils proto port generated_version generated_opencl_kernel libprotobuf_lite port_base port_posix port_linux_base
+        )
+
+add_library(mace_static STATIC IMPORTED GLOBAL)
+add_dependencies(mace_static combined)
+
+set_target_properties(mace_static
+        PROPERTIES
+        IMPORTED_LOCATION ${STATIC_LIB}
+        )
 
 install(TARGETS mace LIBRARY DESTINATION lib)
-install(TARGETS mace_static ARCHIVE DESTINATION lib)
+install(FILES ${STATIC_LIB} DESTINATION lib)

--- a/mace/libmace/CMakeLists.txt
+++ b/mace/libmace/CMakeLists.txt
@@ -25,14 +25,24 @@ else(WIN32)
                 "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n"
                 "addlib ${CMAKE_BINARY_DIR}/mace/port/linux/libport_linux.a")
 endif(ANDROID)
+
+string(CONCAT PORT_LIBS_MRI ${PORT_LIBS} "")
 configure_file("${CMAKE_SOURCE_DIR}/mace/libmace/mace.mri.in" 
                "${CMAKE_BINARY_DIR}/mace/libmace/mace.mri")
 
 set(STATIC_LIB ${CMAKE_BINARY_DIR}/mace/libmace/libmace_static.a)
 add_custom_target(combined ALL
         COMMAND ar -M < ${CMAKE_BINARY_DIR}/mace/libmace/mace.mri
-        DEPENDS mace_API ops core utils proto port generated_version generated_opencl_kernel libprotobuf_lite port_base port_posix port_linux_base
+        DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base
         )
+
+foreach(PORT_LIB ${PORT_LIBS})
+  string(REPLACE "/" ";" PORT_LIST ${PORT_LIB})
+  list(GET PORT_LIST -1 LIB_NAME)
+  get_filename_component(LIB_NAME ${LIB_NAME} NAME_WE)
+  string(SUBSTRING ${LIB_NAME} 3 -1 LIB_NAME)
+  add_dependencies(combined ${LIB_NAME})
+endforeach()
 
 add_library(mace_static STATIC IMPORTED GLOBAL)
 add_dependencies(mace_static combined)

--- a/mace/libmace/CMakeLists.txt
+++ b/mace/libmace/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT APPLE)
 endif(NOT APPLE)
 
 add_library(mace_static STATIC ${LIBMACE_SRCS})
-target_link_libraries(mace_static ops)
+target_link_libraries(mace_static PUBLIC ops)
 
 install(TARGETS mace LIBRARY DESTINATION lib)
 install(TARGETS mace_static ARCHIVE DESTINATION lib)

--- a/mace/libmace/CMakeLists.txt
+++ b/mace/libmace/CMakeLists.txt
@@ -10,19 +10,22 @@ endif(NOT APPLE)
 add_library(mace_API STATIC ${LIBMACE_SRCS})
 target_link_libraries(mace_API ops)
 
+set(STATIC_LIB ${CMAKE_BINARY_DIR}/mace/libmace/libmace_static.a)
 set(BASE_PATH ${CMAKE_BINARY_DIR})
+set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
+              "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n")
 if(ANDROID)
-  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
-                "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n"
+  set(PORT_LIBS ${PORT_LIBS}
                 "addlib ${CMAKE_BINARY_DIR}/mace/port/android/libport_android.a")
-elseif(APPLE)
-  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
-                "addlib ${CMAKE_BINARY_DIR}/mace/port/darwin/libport_darwin.a")
+  if(MACE_ENABLE_RPCMEM)
+    set(PORT_LIBS ${PORT_LIBS}
+                  "\naddlib ${PROJECT_SOURCE_DIR}/third_party/rpcmem/${ANDROID_ABI}/rpcmem.a")
+  endif()
+  
 elseif(WIN32)
-  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/windows/libport_windows.a")
+  set(STATIC_LIB ${CMAKE_BINARY_DIR}/mace/libmace/libmace_static.lib)
 else(WIN32)
-  set(PORT_LIBS "addlib ${CMAKE_BINARY_DIR}/mace/port/posix/libport_posix.a\n"
-                "addlib ${CMAKE_BINARY_DIR}/mace/port/linux_base/libport_linux_base.a\n"
+  set(PORT_LIBS ${PORT_LIBS}
                 "addlib ${CMAKE_BINARY_DIR}/mace/port/linux/libport_linux.a")
 endif(ANDROID)
 
@@ -30,19 +33,52 @@ string(CONCAT PORT_LIBS_MRI ${PORT_LIBS} "")
 configure_file("${CMAKE_SOURCE_DIR}/mace/libmace/mace.mri.in" 
                "${CMAKE_BINARY_DIR}/mace/libmace/mace.mri")
 
-set(STATIC_LIB ${CMAKE_BINARY_DIR}/mace/libmace/libmace_static.a)
-add_custom_target(combined ALL
-        COMMAND ar -M < ${CMAKE_BINARY_DIR}/mace/libmace/mace.mri
-        DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base
-        )
+if(APPLE)
+  add_custom_target(combined ALL
+  COMMAND ${_CMAKE_TOOLCHAIN_PREFIX}libtool -static -o ${STATIC_LIB} 
+          $<TARGET_FILE:mace_API> 
+          $<TARGET_FILE:ops> 
+          $<TARGET_FILE:core> 
+          $<TARGET_FILE:utils> 
+          $<TARGET_FILE:proto> 
+          $<TARGET_FILE:generated_version> 
+          $<TARGET_FILE:generated_opencl_kernel> 
+          $<TARGET_FILE:libprotobuf_lite> 
+          $<TARGET_FILE:port_base> 
+          $<TARGET_FILE:port_posix> 
+          $<TARGET_FILE:port_darwin>
+  DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base port_posix port_darwin
+  )
+elseif(WIN32)
+  add_custom_target(combined ALL
+  COMMAND ${_CMAKE_TOOLCHAIN_PREFIX}LIB.EXE /OUT:${STATIC_LIB} 
+          $<TARGET_FILE:mace_API> 
+          $<TARGET_FILE:ops> 
+          $<TARGET_FILE:core> 
+          $<TARGET_FILE:utils> 
+          $<TARGET_FILE:proto> 
+          $<TARGET_FILE:generated_version> 
+          $<TARGET_FILE:generated_opencl_kernel> 
+          $<TARGET_FILE:libprotobuf_lite> 
+          $<TARGET_FILE:port_base> 
+          $<TARGET_FILE:port_windows> 
+  DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base port_windows
+  )
+elseif(ANDROID)
+  add_custom_target(combined ALL
+    COMMAND ${_CMAKE_TOOLCHAIN_PREFIX}ar -M < ${CMAKE_BINARY_DIR}/mace/libmace/mace.mri
+    DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base port_posix port_linux_base port_android
+    )
+else(ANDROID)
+  add_custom_target(combined ALL
+    COMMAND ar -M < ${CMAKE_BINARY_DIR}/mace/libmace/mace.mri
+    DEPENDS mace_API ops core utils proto generated_version generated_opencl_kernel libprotobuf_lite port_base port_posix port_linux_base port_linux
+    )
+endif(APPLE)
 
-foreach(PORT_LIB ${PORT_LIBS})
-  string(REPLACE "/" ";" PORT_LIST ${PORT_LIB})
-  list(GET PORT_LIST -1 LIB_NAME)
-  get_filename_component(LIB_NAME ${LIB_NAME} NAME_WE)
-  string(SUBSTRING ${LIB_NAME} 3 -1 LIB_NAME)
-  add_dependencies(combined ${LIB_NAME})
-endforeach()
+if(MACE_ENABLE_RPCMEM)
+  add_dependencies(combined rpcmem)
+endif()
 
 add_library(mace_static STATIC IMPORTED GLOBAL)
 add_dependencies(mace_static combined)

--- a/mace/libmace/mace.mri.in
+++ b/mace/libmace/mace.mri.in
@@ -5,7 +5,7 @@ addlib @BASE_PATH@/mace/core/libcore.a
 addlib @BASE_PATH@/mace/utils/libutils.a
 addlib @BASE_PATH@/mace/proto/libproto.a
 addlib @BASE_PATH@/mace/port/libport_base.a
-@PORT_LIBS@
+@PORT_LIBS_MRI@
 addlib @BASE_PATH@/mace/codegen/libgenerated_version.a
 addlib @BASE_PATH@/mace/codegen/libgenerated_opencl_kernel.a
 addlib @BASE_PATH@/third_party/protobuf/src/protobuf-build/libprotobuf-lite.a

--- a/mace/libmace/mace.mri.in
+++ b/mace/libmace/mace.mri.in
@@ -1,0 +1,13 @@
+create @BASE_PATH@/mace/libmace/libmace_static.a
+addlib @BASE_PATH@/mace/libmace/libmace_API.a
+addlib @BASE_PATH@/mace/ops/libops.a
+addlib @BASE_PATH@/mace/core/libcore.a
+addlib @BASE_PATH@/mace/utils/libutils.a
+addlib @BASE_PATH@/mace/proto/libproto.a
+addlib @BASE_PATH@/mace/port/libport_base.a
+@PORT_LIBS@
+addlib @BASE_PATH@/mace/codegen/libgenerated_version.a
+addlib @BASE_PATH@/mace/codegen/libgenerated_opencl_kernel.a
+addlib @BASE_PATH@/third_party/protobuf/src/protobuf-build/libprotobuf-lite.a
+save
+end

--- a/mace/ops/CMakeLists.txt
+++ b/mace/ops/CMakeLists.txt
@@ -58,10 +58,8 @@ if(MACE_ENABLE_OPENCL)
 endif(MACE_ENABLE_OPENCL)
 
 add_library(ops STATIC ${OPS_SRCS})
-target_link_libraries(ops PUBLIC core)
+target_link_libraries(ops PRIVATE core proto utils port)
 
 if(MACE_ENABLE_QUANTIZE)
   add_dependencies(ops tflite)
 endif(MACE_ENABLE_QUANTIZE)
-
-install(TARGETS ops ARCHIVE DESTINATION lib)

--- a/mace/ops/CMakeLists.txt
+++ b/mace/ops/CMakeLists.txt
@@ -58,7 +58,7 @@ if(MACE_ENABLE_OPENCL)
 endif(MACE_ENABLE_OPENCL)
 
 add_library(ops STATIC ${OPS_SRCS})
-target_link_libraries(ops PRIVATE core proto utils port)
+target_link_libraries(ops PUBLIC core)
 
 if(MACE_ENABLE_QUANTIZE)
   add_dependencies(ops tflite)

--- a/mace/port/CMakeLists.txt
+++ b/mace/port/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(port_base STATIC
   file_system.cc
 )
 
-target_link_libraries(port_base PUBLIC utils)
+target_link_libraries(port_base utils)
 
 if(ANDROID)
   add_subdirectory(posix)
@@ -24,5 +24,3 @@ else(WIN32)
   add_subdirectory(linux)
   add_library(port ALIAS port_linux)
 endif(ANDROID)
-
-install(TARGETS port_base ARCHIVE DESTINATION lib)

--- a/mace/port/CMakeLists.txt
+++ b/mace/port/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(port_base STATIC
   file_system.cc
 )
 
-target_link_libraries(port_base utils)
+target_link_libraries(port_base PUBLIC utils)
 
 if(ANDROID)
   add_subdirectory(posix)

--- a/mace/port/android/CMakeLists.txt
+++ b/mace/port/android/CMakeLists.txt
@@ -4,6 +4,6 @@ add_library(port_android STATIC
   env.cc
 )
 
-target_link_libraries(port_android port_linux_base log)
+target_link_libraries(port_android PUBLIC port_linux_base log)
 
 install(TARGETS port_android ARCHIVE DESTINATION lib)

--- a/mace/port/android/CMakeLists.txt
+++ b/mace/port/android/CMakeLists.txt
@@ -4,6 +4,4 @@ add_library(port_android STATIC
   env.cc
 )
 
-target_link_libraries(port_android PUBLIC port_linux_base log)
-
-install(TARGETS port_android ARCHIVE DESTINATION lib)
+target_link_libraries(port_android port_linux_base log)

--- a/mace/port/darwin/CMakeLists.txt
+++ b/mace/port/darwin/CMakeLists.txt
@@ -2,6 +2,4 @@ add_library(port_darwin STATIC
   env.cc
 )
 
-target_link_libraries(port_darwin PUBLIC port_posix)
-
-install(TARGETS port_darwin ARCHIVE DESTINATION lib)
+target_link_libraries(port_darwin port_posix)

--- a/mace/port/darwin/CMakeLists.txt
+++ b/mace/port/darwin/CMakeLists.txt
@@ -2,6 +2,6 @@ add_library(port_darwin STATIC
   env.cc
 )
 
-target_link_libraries(port_darwin port_posix)
+target_link_libraries(port_darwin PUBLIC port_posix)
 
 install(TARGETS port_darwin ARCHIVE DESTINATION lib)

--- a/mace/port/linux/CMakeLists.txt
+++ b/mace/port/linux/CMakeLists.txt
@@ -2,6 +2,6 @@ add_library(port_linux STATIC
   env.cc
 )
 
-target_link_libraries(port_linux port_linux_base)
+target_link_libraries(port_linux PUBLIC port_linux_base)
 
 install(TARGETS port_linux ARCHIVE DESTINATION lib)

--- a/mace/port/linux/CMakeLists.txt
+++ b/mace/port/linux/CMakeLists.txt
@@ -2,6 +2,4 @@ add_library(port_linux STATIC
   env.cc
 )
 
-target_link_libraries(port_linux PUBLIC port_linux_base)
-
-install(TARGETS port_linux ARCHIVE DESTINATION lib)
+target_link_libraries(port_linux port_linux_base)

--- a/mace/port/linux_base/CMakeLists.txt
+++ b/mace/port/linux_base/CMakeLists.txt
@@ -2,6 +2,4 @@ add_library(port_linux_base STATIC
   env.cc
 )
 
-target_link_libraries(port_linux_base PUBLIC port_posix)
-
-install(TARGETS port_linux_base ARCHIVE DESTINATION lib)
+target_link_libraries(port_linux_base port_posix)

--- a/mace/port/linux_base/CMakeLists.txt
+++ b/mace/port/linux_base/CMakeLists.txt
@@ -2,6 +2,6 @@ add_library(port_linux_base STATIC
   env.cc
 )
 
-target_link_libraries(port_linux_base port_posix)
+target_link_libraries(port_linux_base PUBLIC port_posix)
 
 install(TARGETS port_linux_base ARCHIVE DESTINATION lib)

--- a/mace/port/posix/CMakeLists.txt
+++ b/mace/port/posix/CMakeLists.txt
@@ -2,6 +2,4 @@ add_library(port_posix STATIC
   file_system.cc
 )
 
-target_link_libraries(port_posix PUBLIC port_base)
-
-install(TARGETS port_posix ARCHIVE DESTINATION lib)
+target_link_libraries(port_posix port_base)

--- a/mace/port/posix/CMakeLists.txt
+++ b/mace/port/posix/CMakeLists.txt
@@ -2,6 +2,6 @@ add_library(port_posix STATIC
   file_system.cc
 )
 
-target_link_libraries(port_posix port_base)
+target_link_libraries(port_posix PUBLIC port_base)
 
 install(TARGETS port_posix ARCHIVE DESTINATION lib)

--- a/mace/port/windows/CMakeLists.txt
+++ b/mace/port/windows/CMakeLists.txt
@@ -3,6 +3,6 @@ add_library(port_windows STATIC
   file_system.cc
 )
 
-target_link_libraries(port_windows port_base)
+target_link_libraries(port_windows PUBLIC port_base)
 
 install(TARGETS port_windows ARCHIVE DESTINATION lib)

--- a/mace/port/windows/CMakeLists.txt
+++ b/mace/port/windows/CMakeLists.txt
@@ -3,6 +3,4 @@ add_library(port_windows STATIC
   file_system.cc
 )
 
-target_link_libraries(port_windows PUBLIC port_base)
-
-install(TARGETS port_windows ARCHIVE DESTINATION lib)
+target_link_libraries(port_windows port_base)

--- a/mace/proto/CMakeLists.txt
+++ b/mace/proto/CMakeLists.txt
@@ -37,5 +37,3 @@ set_source_files_properties(
     PROPERTIES GENERATED TRUE
 )
 target_link_libraries(proto libprotobuf_lite)
-
-install(TARGETS proto ARCHIVE DESTINATION lib)

--- a/mace/utils/CMakeLists.txt
+++ b/mace/utils/CMakeLists.txt
@@ -8,5 +8,3 @@ add_library(utils STATIC
 if(NOT ANDROID AND NOT WIN32)
   target_link_libraries(utils PUBLIC pthread)
 endif(NOT ANDROID AND NOT WIN32)
-
-install(TARGETS utils ARCHIVE DESTINATION lib)

--- a/third_party/protobuf/protobuf.cmake
+++ b/third_party/protobuf/protobuf.cmake
@@ -56,8 +56,6 @@ add_library(libprotobuf_lite STATIC IMPORTED GLOBAL)
 set_property(TARGET libprotobuf_lite PROPERTY IMPORTED_LOCATION ${PROTOBUF_LITE_LIBRARIES})
 add_dependencies(libprotobuf_lite protobuf)
 
-install(FILES ${PROTOBUF_LITE_LIBRARIES} DESTINATION lib)
-
 set(BUILD_PROTOC TRUE)
 if(COMMAND protoc)
   execute_process(COMMAND protoc OUTPUT_VARIABLE PROTOC_VER)

--- a/third_party/rpcmem/rpcmem.cmake
+++ b/third_party/rpcmem/rpcmem.cmake
@@ -6,5 +6,3 @@ include_directories(SYSTEM "${RPCMEM_INCLUDE_DIR}")
 set(RPCMEM_LIB "${RPCMEM_INSTALL_DIR}/${ANDROID_ABI}/rpcmem.a")
 add_library(rpcmem STATIC IMPORTED GLOBAL)
 set_target_properties(rpcmem PROPERTIES IMPORTED_LOCATION ${RPCMEM_LIB})
-
-install(FILES ${RPCMEM_LIB} DESTINATION lib)


### PR DESCRIPTION
This PR addresses issue: https://github.com/XiaoMi/mace/issues/698

With the provided code, MACE static library is correctly built and installed. It can then be used to run models, tests, benchmarks and used in other projects.