### PR TITLE
Fix mace_run not linking model library

### DIFF
--- a/mace/tools/CMakeLists.txt
+++ b/mace/tools/CMakeLists.txt
@@ -4,6 +4,7 @@ file(GLOB MACE_RUN_SRCS
 add_executable(mace_run ${MACE_RUN_SRCS})
 target_link_libraries(mace_run
   mace_static
+  model
   extra_link_libs_target
   gflags
 )


### PR DESCRIPTION
A previous commit has removed `model` target from `target_link_libraries` of `mace_run` target. Without that, MACE build fails when `RUNMODE=code`.