### PR TITLE
fix: update API usage for APU V4 library compatibility  

### DIFF
--- a/mace/runtimes/apu/v4/neuron_delegate_kernel.cc
+++ b/mace/runtimes/apu/v4/neuron_delegate_kernel.cc
@@ -127,7 +127,11 @@ bool NeuronDelegateKernel::Prepare(const char *file_name,
   }
   NeuronCompilation* compilation = nullptr;
   neuronapi_->NeuronCompilation_create(nn_model_.get(), &compilation);
-  neuronapi_->NeuronCompilation_setSWDilatedConv(compilation, true);
+  if (neuronapi_->NeuronCompilation_setSWDilatedConv != nullptr) {
+    neuronapi_->NeuronCompilation_setSWDilatedConv(compilation, true);
+  } else {
+    LOG(INFO) << "NeuronCompilation_setSWDilatedConv is not supported";
+  }
   const int compilation_result =
       neuronapi_->NeuronCompilation_finish(compilation);
   if (compilation_result != NEURON_NO_ERROR) {


### PR DESCRIPTION
APU V4: Update `NeuronCompilation_setSWDilatedConv` usage to be compatible with earlier versions of APU library.