### PR TITLE
 feat: support APU_CACHE_LOAD_OR_STORE policy to keep cache updated

### DIFF
--- a/include/mace/public/mace.h
+++ b/include/mace/public/mace.h
@@ -158,10 +158,13 @@ enum HexagonPerformanceType {
 // STORE: Compile model using the information from net_def and model_data and
 // store the compiled model.
 // LOAD: Get input/output information from net_def and load pre-compiled model.
+// LOAD_OR_STORE: Try LOAD first. If the pre-compiled model is outdated,
+//                or absent, then STORE.
 enum AcceleratorCachePolicy {
   ACCELERATOR_CACHE_NONE = 0,
   ACCELERATOR_CACHE_STORE = 1,
   ACCELERATOR_CACHE_LOAD = 2,
+  APU_CACHE_LOAD_OR_STORE = 3,
 };
 
 // APU execution preferences.

--- a/mace/flows/apu/apu_ref_flow.cc
+++ b/mace/flows/apu/apu_ref_flow.cc
@@ -42,12 +42,14 @@ MaceStatus ApuRefFlow::Init(const NetDef *net_def,
   auto *apu_runtime = ApuRuntime::Get(main_runtime_);
   auto preference_hint = apu_runtime->GetPreferenceHint();
   auto apu_cache_policy = apu_runtime->GetCachePolicy();
-  bool cache_load = apu_cache_policy ==
-                    AcceleratorCachePolicy::ACCELERATOR_CACHE_LOAD;
-  bool cache_store = apu_cache_policy ==
-                    AcceleratorCachePolicy::ACCELERATOR_CACHE_STORE;
-  const char *file_name = cache_store ? apu_runtime->GetCacheStorePath()
-                                      : apu_runtime->GetCacheLoadPath();
+  bool cache_load = (
+      apu_cache_policy == AcceleratorCachePolicy::ACCELERATOR_CACHE_LOAD ||
+      apu_cache_policy == AcceleratorCachePolicy::APU_CACHE_LOAD_OR_STORE);
+  bool cache_store = (
+      apu_cache_policy == AcceleratorCachePolicy::ACCELERATOR_CACHE_STORE ||
+      apu_cache_policy == AcceleratorCachePolicy::APU_CACHE_LOAD_OR_STORE);
+  const char *file_name = cache_load ? apu_runtime->GetCacheLoadPath()
+                                      : apu_runtime->GetCacheStorePath();
   auto *apu_wrapper = apu_runtime->GetApuWrapper();
   bool ret = false;
   if (cache_load || cache_store) {

--- a/mace/runtimes/apu/v4/apu_wrapper.cc
+++ b/mace/runtimes/apu/v4/apu_wrapper.cc
@@ -43,10 +43,8 @@ bool ApuWrapper::Init(const NetDef &net_def, unsigned const char *model_data,
     return false;
   }
   frontend = new neuron::NeuronDelegateKernel(neuron_, runtime_);
-  MACE_CHECK(!(load & store),
-            "Should not load and store the model simultaneously.");
-  bool ret = frontend->Init(&net_def, model_data, load)
-          && frontend->Prepare(file_name, preference_hint, load, store);
+  bool ret = frontend->Init(&net_def, model_data, file_name,
+                            preference_hint, load, store);
   if (!ret) {
     LOG(ERROR) << "ApuWrapper init failed.";
   } else {

--- a/mace/runtimes/apu/v4/neuron_delegate_kernel.h
+++ b/mace/runtimes/apu/v4/neuron_delegate_kernel.h
@@ -97,10 +97,12 @@ class NeuronDelegateKernel {
       delete [] int32_buffer;
     }
   }
-  bool Init(const NetDef* net_def, unsigned const char *model_data, bool load);
-  bool Prepare(const char *file_name,
-               const APUPreferenceHint preference_hint,
-               bool load, bool store);
+  bool Init(const NetDef *net_def,
+            unsigned const char *model_data,
+            const char *file_name,
+            const APUPreferenceHint preference_hint,
+            const bool load,
+            const bool store);
   bool Eval(const std::map<std::string, Tensor *> &input_tensors,
             std::map<std::string, Tensor *> *output_tensors,
             const uint8_t boost_hint);
@@ -110,7 +112,11 @@ class NeuronDelegateKernel {
                          unsigned const char *model_data);
   bool AddOpsAndTensors(const NetDef* net_def, unsigned const char *model_data);
   bool BuildGraph(const NetDef* net_def, unsigned const char *model_data);
-
+  bool CompileModel(const NetDef *net_def,
+                    unsigned const char *model_data,
+                    const APUPreferenceHint preference_hint,
+                    const bool store,
+                    const char *file_name);
   std::vector<NeuronMemory*> PrepareInputTensors(
       const std::map<std::string, Tensor *> &input_tensors,
       NeuronExecution* execution);

--- a/mace/tools/mace_run.cc
+++ b/mace/tools/mace_run.cc
@@ -180,7 +180,7 @@ DEFINE_int32(apu_preference_hint, 1,
 DEFINE_int32(opencl_cache_reuse_policy,
             1,
             "0:NONE/1:REUSE_SAME_GPU");
-DEFINE_int32(accelerator_cache_policy, 0, "0:NONE/1:STORE/2:LOAD");
+DEFINE_int32(accelerator_cache_policy, 0, "0:NONE/1:STORE/2:LOAD/3:APU_LOAD_OR_STORE");
 DEFINE_bool(benchmark, false, "enable benchmark op");
 DEFINE_bool(fake_warmup, false, "enable fake warmup");
 

--- a/tools/converter.py
+++ b/tools/converter.py
@@ -1297,7 +1297,7 @@ def parse_args():
         "--accelerator_cache_policy",
         type=int,
         default=DefaultValues.accelerator_cache_policy,
-        help="0:NONE/1:STORE/2:LOAD")
+        help="0:NONE/1:STORE/2:LOAD/3:APU_LOAD_OR_STORE")
     run.add_argument(
         "--accelerator_binary_file",
         type=str,

--- a/tools/device.py
+++ b/tools/device.py
@@ -342,7 +342,7 @@ class DeviceWrapper:
                         apu_src_file = model_tag + ".bin"
                         accelerator_storage_file = os.path.join(self.data_dir,
                                                                 apu_src_file)
-                elif accelerator_cache_policy == 2:
+                elif accelerator_cache_policy in (2, 3):
                     if len(accelerator_binary_file) == 0:
                         apu_src_file = model_tag + ".bin"
                         accelerator_binary_file = '{}/apu_init_cache/{}'.format(mace_model_dir, apu_src_file)


### PR DESCRIPTION
add policy `APU_CACHE_LOAD_OR_STORE`:   
1) try  load cache first
2) if cache is outdated or absent, re-compile and store

the flags in `mace_run` will be

```
 --accelerator_cache_policy=3 
 --accelerator_binary_file=path_to_cache
```