### PR TITLE
modify base_engine.cc

### DIFF
--- a/mace/libmace/engines/base_engine.cc
+++ b/mace/libmace/engines/base_engine.cc
@@ -43,7 +43,7 @@ BaseEngine::BaseEngine(const MaceEngineConfig &config)
       model_data_(nullptr), op_registry_(new OpRegistry),
       op_delegator_registry_(new OpDelegatorRegistry),
       config_impl_(config.impl_) {
-#ifdef MACE_ENABLE_RPCMEM
+#ifndef MACE_ENABLE_RPCMEM
   runtime_context_ = make_unique<IonRuntimeContext>(
       thread_pool_.get(), rpcmem_factory::CreateRpcmem());
 #else


### PR DESCRIPTION
Problem to solve: Use cmake to build this project and get a libmace_static.a. When used by a android app, libmace_static.a cannot find mace::rpcmem_factory::CreateRpcmem.