### PR TITLE
Fix the wrong number of compilation threads

### DIFF
--- a/tools/cmake/cmake-build-armeabi-v7a.sh
+++ b/tools/cmake/cmake-build-armeabi-v7a.sh
@@ -69,5 +69,5 @@ cmake -DANDROID_ABI="armeabi-v7a" \
       -DMACE_ENABLE_RPCMEM=ON                                \
       -DCMAKE_INSTALL_PREFIX=install                         \
       ../../..
-make -j$(nproc)1 && make install
+make -j$(nproc) && make install
 cd ../../..


### PR DESCRIPTION
There is a small bug here, unlike other cmake build scripts, that causes the system to get particularly stuck.