### PR TITLE
fix: linux input path error

### DIFF
--- a/tools/python/run_model.py
+++ b/tools/python/run_model.py
@@ -183,8 +183,11 @@ def run_model_for_device(flags, args, dev, model_name, model_conf):
                                 input_tensors_info[ModelKeys.input_data_types])
 
         dev.install(Target(tmpdirname), install_dir + "/validate_in")
-        target_input_file = "%s/validate_in/%s" % (
-            install_dir, model_name)
+        target_input_file = "%s/validate_in/" % install_dir
+        if flags.device_conf:
+            target_input_file += tmpdirname.split("/")[-1]
+            target_input_file += "/"
+        target_input_file += model_name
         target_output_dir = "%s/validate_out" % install_dir
         dev.mkdir(target_output_dir)
         target_output_file = target_output_dir + "/" + model_name


### PR DESCRIPTION
trivial path fix for running models for linux embedded arm64 devices

input_file is now fixed to `/tmp/mace_run/{model name}/validate_in/{tmpdir}/{model name}` from `/tmp/mace_run/{model name}/validate_in/{model name}`

not sure if this is a problem for other devices, so I added if condition, so that my modification only takes effect on linux environment